### PR TITLE
Revoke D-Bus access for network purposes

### DIFF
--- a/org.localsend.localsend_app.yml
+++ b/org.localsend.localsend_app.yml
@@ -12,9 +12,6 @@ finish-args:
   - --share=network
   - --socket=wayland
   - --socket=fallback-x11
-  # Need to detect network info
-  - --system-talk-name=org.freedesktop.NetworkManager
-  - --system-talk-name=org.freedesktop.hostname1
   # Allow access to home directory, see https://github.com/localsend/localsend/issues/256
   - --filesystem=xdg-download
   # Tray indicator


### PR DESCRIPTION
I don't see why these are needed, not sure. It works fine, and checking blame apparently the app wouldn't start without them, but it seems fine now, I've been running without these just fine.