### PR TITLE
Update Flatpak runtime and filesystem permissions

### DIFF
--- a/org.localsend.localsend_app.yml
+++ b/org.localsend.localsend_app.yml
@@ -1,6 +1,6 @@
 app-id: org.localsend.localsend_app
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.vala
@@ -16,7 +16,7 @@ finish-args:
   - --system-talk-name=org.freedesktop.NetworkManager
   - --system-talk-name=org.freedesktop.hostname1
   # Allow access to home directory, see https://github.com/localsend/localsend/issues/256
-  - --filesystem=xdg-download
+  - --filesystem=home
   # Tray indicator
   - --talk-name=org.kde.StatusNotifierWatcher
 build-options:


### PR DESCRIPTION
Bump runtime-version to '25.08' and change filesystem permission from xdg-download to home in org.localsend.localsend_app.yml for broader home directory access.
This change will fix drag and drop only working on files from download directory previously.