### PR TITLE
Change filesystem permission to host

### DIFF
--- a/org.localsend.localsend_app.yml
+++ b/org.localsend.localsend_app.yml
@@ -12,11 +12,10 @@ finish-args:
   - --share=network
   - --socket=wayland
   - --socket=fallback-x11
-  # Need to detect network info
+  - --filesystem=host
+  # Needed to detect network info
   - --system-talk-name=org.freedesktop.NetworkManager
   - --system-talk-name=org.freedesktop.hostname1
-  # Allow access to home directory, see https://github.com/localsend/localsend/issues/256
-  - --filesystem=xdg-download
   # Tray indicator
   - --talk-name=org.kde.StatusNotifierWatcher
 build-options:


### PR DESCRIPTION
Non-Flatpak LocalSend allows drag-n-drop and uploading files from any place, so let's adjust the filesystem permission on it to be default to host, allowing the user to use the localsend flatpak as expected.

Defaulting just to xdg-download, while technically better, creates an usability problem. Users may want to share a variety of files.

Note that this only exposes directories that likely contain user files. It does not expose system-wide libraries and other related things. See https://docs.flatpak.org/en/latest/flatpak-command-reference.html#flatpak-metadata.

Many popular Flatpak apps have filesystem=host such as OBS Studio and VLC.

Closes https://github.com/localsend/localsend/issues/2849
Closes https://github.com/localsend/localsend/issues/2320
Closes https://github.com/localsend/localsend/issues/1909
Closes https://github.com/localsend/localsend/issues/513
Closes https://github.com/flathub/org.localsend.localsend_app/pull/73 (runtime was updated by another commit)

edit: removed https://github.com/localsend/localsend/issues/2306 from the list of "Closes"